### PR TITLE
Add building search and selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "fuse.js": "^6.6.2",
     "maplibre-gl": "^5.6.2",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+import Fuse from "fuse.js";
+import { useStore } from "./store";
 
 const BOUNDS = [
   [-118.456, 34.058],
@@ -10,6 +12,8 @@ const BOUNDS = [
 export default function App() {
   const mapRef = useRef(null);
   const [status, setStatus] = useState("Click the map");
+  const fuseRef = useRef(null);
+  const { selectedId, setSelectedId } = useStore();
 
   useEffect(() => {
     const map = new maplibregl.Map({
@@ -77,17 +81,23 @@ export default function App() {
         paint: { "line-color": "#1b6ef3", "line-width": 1 },
       });
 
-      map.on("click", (e) => {
-        // simple feedback: show the clicked building name if any
-        const features = map.queryRenderedFeatures(e.point, {
-          layers: ["bldg-fill"],
-        });
-        if (features.length) {
-          const f = features[0];
-          setStatus(`Inside: ${f.properties.name}`);
-        } else {
-          setStatus("Miss!");
-        }
+      map.addLayer({
+        id: "bldg-hi",
+        type: "line",
+        source: "campus",
+        filter: ["==", ["get", "id"], ""],
+        paint: { "line-color": "#ff9f1c", "line-width": 3 },
+      });
+
+      const data = map.getSource("campus")._data;
+      fuseRef.current = new Fuse(data.features, {
+        keys: ["properties.name", "properties.aliases"],
+        threshold: 0.3,
+      });
+
+      map.on("click", "bldg-fill", (e) => {
+        const f = e.features[0];
+        setSelectedId(f.properties.id);
       });
 
       map.getCanvas().style.cursor = "crosshair";
@@ -95,6 +105,23 @@ export default function App() {
 
     return () => map.remove();
   }, []);
+
+  useEffect(() => {
+    if (!mapRef.current || !selectedId) return;
+    const map = mapRef.current;
+    map.setFilter("bldg-hi", ["==", ["get", "id"], selectedId]);
+    const f = map
+      .getSource("campus")
+      ._data.features.find((x) => x.properties.id === selectedId);
+    if (f) {
+      const b = new maplibregl.LngLatBounds();
+      (f.geometry.type === "Polygon" ? [f.geometry.coordinates] : f.geometry.coordinates)
+        .flat(2)
+        .forEach(([lng, lat]) => b.extend([lng, lat]));
+      map.fitBounds(b, { padding: 80, maxZoom: 18, duration: 600 });
+      setStatus(`Inside: ${f.properties.name}`);
+    }
+  }, [selectedId]);
 
   return (
     <div
@@ -106,6 +133,17 @@ export default function App() {
     >
       <aside style={{ padding: 12, borderRight: "1px solid #e7e7e7" }}>
         <h3 style={{ margin: "6px 0" }}>UCLA Map Trainer</h3>
+        <input
+          placeholder="Search buildings…"
+          style={{ width: "100%", padding: 8, borderRadius: 8, border: "1px solid #ccd" }}
+          onKeyDown={(e) => {
+            if (e.key !== "Enter") return;
+            const q = e.currentTarget.value.trim();
+            if (!q) return;
+            const hits = fuseRef.current.search(q);
+            if (hits.length) setSelectedId(hits[0].item.properties.id);
+          }}
+        />
         <div
           style={{
             marginTop: 8,

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,5 @@
+import { create } from "zustand";
+export const useStore = create((set) => ({
+  selectedId: null,
+  setSelectedId: (id) => set({ selectedId: id }),
+}));


### PR DESCRIPTION
## Summary
- add Zustand store for selected building
- integrate Fuse.js search and highlight selection on map
- expose search input in sidebar to fly to matched building

## Testing
- `npm test` *(fails: no test specified)*
- `npx vite build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu'; dependencies couldn't be installed due to npm 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c331784788322b5ead636f9d0fb66