### PR TITLE
Add initial Vitest test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest",
     "dev": "vite"
   },
   "keywords": [],
@@ -19,6 +19,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.0",
-    "vite": "5.4"
+    "vite": "5.4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/components/SearchBox.test.jsx
+++ b/src/components/SearchBox.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBox from './SearchBox';
+import { useStore } from '../store';
+
+const mockFuse = {
+  search: vi.fn(() => [{ item: { properties: { id: '1', name: 'Test Building' } } }]),
+};
+
+describe('SearchBox', () => {
+  beforeEach(() => {
+    useStore.setState({ selectedId: null, query: '', activeIndex: -1 });
+    mockFuse.search.mockClear();
+  });
+
+  it('shows results and updates store on select', () => {
+    render(<SearchBox fuse={mockFuse} />);
+    const input = screen.getByPlaceholderText(/search buildings/i);
+    fireEvent.change(input, { target: { value: 'Te' } });
+
+    expect(mockFuse.search).toHaveBeenCalledWith('Te');
+
+    const option = screen.getByRole('option', { name: 'Test Building' });
+    fireEvent.mouseDown(option);
+
+    expect(useStore.getState().selectedId).toBe('1');
+    expect(input.value).toBe('Test Building');
+  });
+});

--- a/src/store.test.js
+++ b/src/store.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useStore } from './store';
+
+afterEach(() => {
+  useStore.setState({ selectedId: null, query: '', activeIndex: -1 });
+});
+
+describe('useStore', () => {
+  it('updates selectedId', () => {
+    const { setSelectedId } = useStore.getState();
+    setSelectedId('abc');
+    expect(useStore.getState().selectedId).toBe('abc');
+  });
+
+  it('updates query and activeIndex', () => {
+    const { setQuery, setActiveIndex } = useStore.getState();
+    setQuery('hi');
+    setActiveIndex(2);
+    const state = useStore.getState();
+    expect(state.query).toBe('hi');
+    expect(state.activeIndex).toBe(2);
+  });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,4 +3,8 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./setupTests.js",
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment
- add tests for Zustand store state updates
- add SearchBox component test using Testing Library

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3ae5ea6c8322ad5ac568f472a8ff