### PR TITLE
Smooth building centering with fixed zoom

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -187,11 +187,8 @@ export default function App() {
       (x) => x.properties.id === selectedId
     );
     if (f) {
-      map.fitBounds(featureBounds(f), {
-        padding: 80,
-        maxZoom: 18,
-        duration: 500,
-      });
+      const center = featureBounds(f).getCenter();
+      map.easeTo({ center, zoom: 18, duration: 800 });
       setStatus(`Selected: ${f.properties.name}`);
     }
   }, [selectedId]);


### PR DESCRIPTION
## Summary
- center selected buildings with animated `easeTo` instead of `fitBounds`
- use fixed zoom level to avoid size-dependent scaling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689c3b37a7108322b664b496b941967c