### PR TITLE
Simplify build categories

### DIFF
--- a/ucla_geojson/builder.py
+++ b/ucla_geojson/builder.py
@@ -101,7 +101,7 @@ def process_features(osm_data):
         centroid = [round(c.x, 6), round(c.y, 6)]
 
         zone = determine_zone(centroid)
-        category, subtype, important_off = determine_category(tags, name, zone)
+        category, important_off = determine_category(tags, name, zone)
 
         fid = f"{slugify(name)}-{hash_centroid(centroid)}"
         props = {
@@ -110,7 +110,6 @@ def process_features(osm_data):
             "aliases": aliases,
             "zone": zone,
             "category": category,
-            "subtype": subtype,
             "important_off_campus": bool(important_off),
             "centroid": centroid,
             "osm_ids": [osm_id_str],

--- a/ucla_geojson/constants.py
+++ b/ucla_geojson/constants.py
@@ -17,12 +17,12 @@ GREEK_NAME_RE = (
 )
 
 IMPORTANT_OFF_CAMPUS = {
-    # substrings -> (category, subtype)
-    "hammer museum": ("Libraries/Museums", "Museum"),
-    "geffen playhouse": ("Performance/Venues", "Playhouse"),
-    "ronald reagan ucla medical center": ("Medical/Health", "Hospital"),
-    "ucla health westwood": ("Medical/Health", "Clinic/Health"),
-    "marina aquatics center": ("Athletic/Recreational", "Boathouse"),
+    # substrings -> category
+    "hammer museum": "Museum",
+    "geffen playhouse": "Playhouse",
+    "ronald reagan ucla medical center": "Hospital",
+    "ucla health westwood": "Clinic/Health",
+    "marina aquatics center": "Boathouse",
 }
 
 BLACKLIST = {

--- a/ucla_geojson/probe.py
+++ b/ucla_geojson/probe.py
@@ -28,12 +28,10 @@ def probe_duplicate_centroids():
 
 def feature_type_tree():
     campus = open_campus()
-    subtypes = set()
+    categories = set()
 
     for feature in campus:
         props = feature["properties"]
-        category = props["category"]
-        subtype = props["subtype"]
-        subtypes.add(f"{category}: {subtype}")
+        categories.add(props["category"])
 
-    print(*sorted(subtypes), sep="\n")
+    print(*sorted(categories), sep="\n")


### PR DESCRIPTION
## Summary
- Remove separate categories and promote former subtypes to categories
- Adjust builder and probe to work without subtype field
- Update off-campus mapping to match new category scheme

## Testing
- `python -m py_compile build_ucla_geojson.py ucla_geojson/*.py`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d7ddec23c83229b927946e3e056f1