### PR TITLE
Add detailed categories for housing and athletics

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -130,6 +130,14 @@ export default function MapView({
       "#ff7f0e",
       "Athletic/Recreational",
       "#2ca02c",
+      "Pool",
+      "#2ca02c",
+      "Stadium",
+      "#ff9896",
+      "Sports Court/Pitch",
+      "#c5b0d5",
+      "Sports Field",
+      "#98df8a",
       "Dining",
       "#d62728",
       "Libraries/Museums",
@@ -142,6 +150,10 @@ export default function MapView({
       "#7f7f7f",
       "Residential",
       "#bcbd22",
+      "On-Campus Housing",
+      "#bcbd22",
+      "Off-Campus Housing",
+      "#e7ba52",
       "Service/Support",
       "#17becf",
       "#6aa9ff",
@@ -197,6 +209,37 @@ export default function MapView({
       // campus data
       const res = await fetch("/campus.geojson");
       const data = await res.json();
+
+      data.features.forEach((f) => {
+        const p = f.properties;
+        const name = p.name?.toLowerCase() || "";
+        if (p.category === "Residential") {
+          p.category = p.zone === "Westwood" ? "Off-Campus Housing" : "On-Campus Housing";
+        } else if (p.category === "Athletic/Recreational") {
+          if (name.includes("pool")) {
+            p.category = "Pool";
+          } else if (name.includes("stadium") || name.includes("pavilion")) {
+            p.category = "Stadium";
+          } else if (
+            name.includes("court") ||
+            name.includes("pitch") ||
+            name.includes("tennis")
+          ) {
+            p.category = "Sports Court/Pitch";
+          } else if (
+            name.includes("field") ||
+            name.includes("track") ||
+            name.includes("intramural") ||
+            name.includes("im field") ||
+            name.includes("drake") ||
+            name.includes("spaulding")
+          ) {
+            p.category = "Sports Field";
+          } else {
+            p.category = "Sports Field";
+          }
+        }
+      });
 
       dataRef.current = data;
       map.addSource("campus", { type: "geojson", data });

--- a/ucla_geojson/classification.py
+++ b/ucla_geojson/classification.py
@@ -52,21 +52,16 @@ ADMIN_HINTS = {
     "career center",
 }
 
-ATHLETIC_HINTS = {
-    "pauley",
-    "pavilion",
-    "stadium",
+POOL_HINTS = {"pool", "aquatic"}
+STADIUM_HINTS = {"stadium", "pavilion"}
+COURT_HINTS = {"court", "tennis"}
+FIELD_HINTS = {
     "track",
+    "field",
     "intramural",
     "im field",
     "drake",
     "spaulding",
-    "gym",
-    "athletic",
-    "marina aquatic",
-    "boathouse",
-    "tennis",
-    "pool",
 }
 
 DINING_HINTS = {
@@ -218,13 +213,7 @@ def determine_category(tags: Dict[str, str], name: str, zone: str) -> Tuple[str,
         or re.search(GREEK_NAME_RE, name, re.I)
         or _hint_in(name_norm, HOUSING_HINTS)
     ):
-        cat = (
-            "Fraternity/Sorority"
-            if amenity in {"fraternity", "sorority"}
-            or btype in {"fraternity", "sorority"}
-            or re.search(GREEK_NAME_RE, name, re.I)
-            else "Housing"
-        )
+        cat = "Off-Campus Housing" if zone == "Westwood" else "On-Campus Housing"
         return cat, False
 
     if (
@@ -245,15 +234,17 @@ def determine_category(tags: Dict[str, str], name: str, zone: str) -> Tuple[str,
     }:
         return "Performing Arts", zone == "Westwood"
 
-    if leisure in {
-        "stadium",
-        "sports_centre",
-        "pitch",
-        "swimming_pool",
-        "track",
-        "tennis_court",
-    } or _hint_in(name_norm, ATHLETIC_HINTS):
-        return "Athletics", False
+    if leisure == "swimming_pool" or _hint_in(name_norm, POOL_HINTS):
+        return "Pool", False
+
+    if leisure == "stadium" or _hint_in(name_norm, STADIUM_HINTS):
+        return "Stadium", False
+
+    if leisure == "tennis_court" or _hint_in(name_norm, COURT_HINTS):
+        return "Sports Court/Pitch", False
+
+    if leisure in {"pitch", "track", "sports_centre"} or _hint_in(name_norm, FIELD_HINTS):
+        return "Sports Field", False
 
     if (
         leisure in {"park", "garden"}
@@ -277,5 +268,5 @@ def determine_category(tags: Dict[str, str], name: str, zone: str) -> Tuple[str,
     if zone in {"North Campus", "South Campus"}:
         return "Academic/Research", False
     if zone == "The Hill":
-        return "Housing", False
+        return "On-Campus Housing", False
     return "Unknown", False


### PR DESCRIPTION
## Summary
- split housing into on-campus vs off-campus classes
- classify athletic facilities into pools, stadiums, sports courts/pitches, and sports fields
- color map and data load logic updated for new categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d943c54ec8322a31b222156496065