### PR TITLE
Persist map and checkbox state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useStore } from "./store";
 import MapView from "./components/MapView";
 import Sidebar from "./components/Sidebar";
@@ -7,8 +7,32 @@ export default function App() {
   const { selectedId, setSelectedId } = useStore();
   const [fuse, setFuse] = useState(null);
   const [status, setStatus] = useState("Click the map");
-  const [showNamed, setShowNamed] = useState(true);
-  const [showUnnamed, setShowUnnamed] = useState(true);
+  const [showNamed, setShowNamed] = useState(() => {
+    if (typeof localStorage !== "undefined") {
+      const v = localStorage.getItem("showNamed");
+      if (v !== null) return v === "true";
+    }
+    return true;
+  });
+  const [showUnnamed, setShowUnnamed] = useState(() => {
+    if (typeof localStorage !== "undefined") {
+      const v = localStorage.getItem("showUnnamed");
+      if (v !== null) return v === "true";
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("showNamed", showNamed);
+    }
+  }, [showNamed]);
+
+  useEffect(() => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("showUnnamed", showUnnamed);
+    }
+  }, [showUnnamed]);
 
   return (
     <div

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -93,6 +93,14 @@ export default function MapView({
   };
 
   useEffect(() => {
+    let savedView = null;
+    if (typeof localStorage !== "undefined") {
+      try {
+        savedView = JSON.parse(localStorage.getItem("lastView"));
+      } catch {
+        savedView = null;
+      }
+    }
     const map = new maplibregl.Map({
       container: "map",
       style: {
@@ -107,8 +115,10 @@ export default function MapView({
           },
         ],
       },
-      center: [-118.4452, 34.0689],
-      zoom: 16,
+      center: savedView
+        ? [savedView.lng, savedView.lat]
+        : [-118.4452, 34.0689],
+      zoom: savedView ? savedView.zoom : 16,
       minZoom: 15,
       maxZoom: 19,
       maxBounds: BOUNDS,
@@ -116,6 +126,15 @@ export default function MapView({
       pitchWithRotate: false,
     });
     mapRef.current = map;
+    map.on("moveend", () => {
+      if (typeof localStorage !== "undefined") {
+        const c = map.getCenter();
+        localStorage.setItem(
+          "lastView",
+          JSON.stringify({ lng: c.lng, lat: c.lat, zoom: map.getZoom() })
+        );
+      }
+    });
     const hoverPopup = new maplibregl.Popup({
       closeButton: false,
       closeOnClick: false,


### PR DESCRIPTION
## Summary
- Restore checkbox visibility settings from localStorage on load and update storage when changed
- Save and load last map center/zoom so users return to previous view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d967d8f4c83229d8046598e4ce6ac