### PR TITLE
feat: show GeoJSON load failure states

### DIFF
--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -1,0 +1,32 @@
+.spinner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-overlay {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.error-overlay button {
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Summary
- show spinner while GeoJSON loads
- display error overlay with retry when GeoJSON fetch fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d96a52f308322a5dd815a546ea706