### PR TITLE
Prefer smallest polygon on hover/click

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -373,14 +373,26 @@ export default function MapView({
         })
       );
 
-      // click selects feature
+      // choose the smallest-area feature to prefer children over parents
+      const smallestFeature = (features) =>
+        features.reduce(
+          (smallest, f) =>
+            (f.properties.area ?? Infinity) <
+            (smallest.properties.area ?? Infinity)
+              ? f
+              : smallest,
+          features[0]
+        );
+
+      // click selects smallest feature
       map.on("click", "bldg-fill", (e) => {
-        const f = e.features[0];
+        const f = smallestFeature(e.features);
         setSelectedId(f.properties.id);
       });
 
+      // hover highlights smallest feature
       map.on("mousemove", "bldg-fill", (e) => {
-        const f = e.features[0];
+        const f = smallestFeature(e.features);
         hoverRef.current = f.properties.id;
         hoverPopup.setLngLat(e.lngLat).setText(f.properties.name).addTo(map);
         applyHover();


### PR DESCRIPTION
## Summary
- prefer smallest-area feature for clicks and hover to prioritize child polygons over parents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d96cd98e48322bf9c9649972f73a8