### PR TITLE
Label unnamed features by type

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -52,8 +52,17 @@ export default function MapView({
   const hoverRef = useRef("");
   const filterRef = useRef(null);
 
-  const hasName = ["!=", ["get", "name"], "Unnamed Building"];
-  const noName = ["==", ["get", "name"], "Unnamed Building"];
+  const UNNAMED_PREFIX = "Unnamed ";
+  const hasName = [
+    "!=",
+    ["slice", ["get", "name"], 0, UNNAMED_PREFIX.length],
+    UNNAMED_PREFIX,
+  ];
+  const noName = [
+    "==",
+    ["slice", ["get", "name"], 0, UNNAMED_PREFIX.length],
+    UNNAMED_PREFIX,
+  ];
 
   const computeBaseFilter = () => {
     if (showNamed && showUnnamed) return ["all"]; // no-op filter

--- a/ucla_geojson/builder.py
+++ b/ucla_geojson/builder.py
@@ -54,19 +54,30 @@ def process_features(osm_data):
             or tags.get("loc_name")
             or tags.get("ref")
             or tags.get("operator")
-            or "Unnamed Building"
         )
+        if not name:
+            feature_type = (
+                tags.get("natural")
+                or tags.get("leisure")
+                or tags.get("landuse")
+                or building_type
+                or tags.get("amenity")
+                or "feature"
+            ).lower()
+            if feature_type == "yes":
+                feature_type = "building"
+            feature_type = feature_type.replace("_", " ")
+            name = f"Unnamed {feature_type.title()}"
 
-        if name == "Unnamed Building" and A < MIN_AREA_UNNAMED:
+        if name.startswith("Unnamed ") and A < MIN_AREA_UNNAMED:
             continue
         if building_type in EXCLUDE_BUILDINGS and A < MIN_AREA_EXCLUDE:
             continue
-        if A < MIN_AREA_EXCLUDE and name == "Unnamed Building":
+        if A < MIN_AREA_EXCLUDE and name.startswith("Unnamed "):
             continue
         if any(re.search(pattern, name, re.I) for pattern in BLACKLIST):
             continue
-
-        if name == "Unnamed Building":
+        if name.startswith("Unnamed "):
             amenity = (tags.get("amenity") or "").lower()
             parking = (tags.get("parking") or "").lower()
             bldg = (tags.get("building") or "").lower()

--- a/ucla_geojson/fetcher.py
+++ b/ucla_geojson/fetcher.py
@@ -1,4 +1,6 @@
-import requests
+import json
+import urllib.parse
+import urllib.request
 
 from .constants import BBOX_QUERY, GREEK_NAME_RE, OVERPASS_URL
 
@@ -76,8 +78,8 @@ area["amenity"="university"]["name"~"^(University of California, Los Angeles|UCL
 (.campus; .ucla_related; .greek;);
 out body; >; out skel qt;
 """
-    r = requests.get(OVERPASS_URL, params={"data": query})
-    r.raise_for_status()
-    data = r.json()
+    url = f"{OVERPASS_URL}?{urllib.parse.urlencode({'data': query})}"
+    with urllib.request.urlopen(url) as resp:
+        data = json.load(resp)
     print(f"Fetched {len(data.get('elements', []))} elements")
     return data


### PR DESCRIPTION
## Summary
- Label features without names as "Unnamed" plus their specific type (e.g., park, grass)
- Match unnamed features in the map by checking the "Unnamed " prefix
- Switch OSM fetcher to use urllib instead of requests

## Testing
- `npm test`
- `python build_ucla_geojson.py` *(fails: ModuleNotFoundError: No module named 'pyproj')*


------
https://chatgpt.com/codex/tasks/task_e_689d979759ec8322a4aa4b7cbe0c69c8