### PR TITLE
Add query-at-point tool

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ export default function App() {
   const [showNamed, setShowNamed] = useState(true);
   const [showUnnamed, setShowUnnamed] = useState(true);
   const [colorBy, setColorBy] = useState("category");
+  const [queryMode, setQueryMode] = useState(false);
+  const [queryResults, setQueryResults] = useState([]);
 
   return (
     <div
@@ -28,6 +30,9 @@ export default function App() {
         setShowUnnamed={setShowUnnamed}
         colorBy={colorBy}
         setColorBy={setColorBy}
+        queryMode={queryMode}
+        setQueryMode={setQueryMode}
+        queryResults={queryResults}
       />
       <MapView
         showNamed={showNamed}
@@ -37,6 +42,8 @@ export default function App() {
         setSelectedId={setSelectedId}
         setStatus={setStatus}
         setFuse={setFuse}
+        queryMode={queryMode}
+        setQueryResults={setQueryResults}
       />
     </div>
   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,6 +9,9 @@ export default function Sidebar({
   setShowUnnamed,
   colorBy,
   setColorBy,
+  queryMode,
+  setQueryMode,
+  queryResults,
 }) {
   return (
     <aside
@@ -71,6 +74,19 @@ export default function Sidebar({
           </label>
         </div>
       </div>
+      <button
+        onClick={() => setQueryMode((m) => !m)}
+        style={{
+          marginTop: 8,
+          padding: "6px 8px",
+          background: queryMode ? "#ddeeff" : "#fff",
+          border: "1px solid #ccd",
+          borderRadius: 4,
+          cursor: "pointer",
+        }}
+      >
+        {queryMode ? "Exit query" : "Query at point"}
+      </button>
       <div
         style={{
           marginTop: 8,
@@ -81,6 +97,36 @@ export default function Sidebar({
       >
         {status}
       </div>
+      {queryResults.length > 0 && (
+        <div
+          style={{
+            marginTop: 8,
+            maxHeight: "30vh",
+            overflowY: "auto",
+            border: "1px solid #e0e0e0",
+            borderRadius: 4,
+            padding: 8,
+            background: "#fff",
+          }}
+        >
+          {queryResults.map((f, idx) => (
+            <div key={idx} style={{ marginBottom: 8 }}>
+              <div style={{ fontWeight: "bold" }}>
+                {f.properties.name || f.properties.id || `Feature ${idx + 1}`}
+              </div>
+              <pre
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  fontSize: 12,
+                }}
+              >
+                {JSON.stringify(f.properties, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
       <div
         style={{
           position: "absolute",


### PR DESCRIPTION
## Summary
- add sidebar toggle to query map features at a clicked point
- wire up state and map logic to list intersecting feature properties

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1678129c8322aeb73535633c1d2c