### PR TITLE
Highlight smallest area on hover

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -441,7 +441,11 @@ export default function MapView({
       // hover highlights smallest feature
       map.on("mousemove", "bldg-fill", (e) => {
         if (queryModeRef.current) return;
-        const f = smallestFeature(e.features);
+        const features = map.queryRenderedFeatures(e.point, {
+          layers: ["bldg-fill"],
+        });
+        if (!features.length) return;
+        const f = smallestFeature(features);
         hoverRef.current = f.properties.id;
         hoverPopup.setLngLat(e.lngLat).setText(f.properties.name).addTo(map);
         applyHover();


### PR DESCRIPTION
## Summary
- Hover now queries all overlapping features and highlights the smallest by area

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1f07d3e88322affd131a40f8515b