### PR TITLE
fix: reuse helper to avoid withBase initialization error

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -389,11 +389,7 @@ export default function MapView({
         map.setFilter("bldg-label", withBase(base, hasName));
 
         // Keep hover/highlight in sync with the same base
-        const withBase = (b, extra) => [
-          "all",
-          ...(b ? [b] : []),
-          ...(extra ? [extra] : []),
-        ];
+        // Reuse top-level withBase helper instead of redeclaring
         map.setFilter(
           "bldg-hover",
           withBase(base, ["==", ["get", "id"], hoverRef.current])


### PR DESCRIPTION
## Summary
- reuse top-level withBase helper instead of redeclaring inside styledata handler
- prevents `can't access lexical declaration 'withBase2' before initialization` runtime error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1fd81ca08322976ccd63826186ce