### PR TITLE
Deselect selection when clicking empty map area

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -436,6 +436,9 @@ export default function MapView({
           const f = smallestFeature(features);
           setSelectedId(f.properties.id);
         }
+        if (features.length === 0) {
+          setSelectedId(null);
+        }
       });
 
       // hover quickly then refine to smallest feature after a short delay


### PR DESCRIPTION
## Summary
- clear selection when clicking on map background with no features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e236e97dc8322845e78b2e411f164