### PR TITLE
Rename unnamed features based on nearby named features

### DIFF
--- a/ucla_geojson/builder.py
+++ b/ucla_geojson/builder.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime, timezone
 
-from shapely.geometry import MultiPolygon, Polygon, mapping, shape
+from shapely.geometry import MultiPolygon, Polygon, Point, mapping, shape
 from shapely.geometry.polygon import orient
 from shapely.ops import transform, unary_union
 
@@ -27,6 +27,9 @@ CAMPUS_RELATION_ID = 7493269
 # Minimum ratio of a feature's area that must overlap the campus boundary to
 # consider it on campus
 ON_CAMPUS_THRESHOLD = 0.5
+
+# Maximum distance to rename unnamed features by proximity (meters)
+NEARBY_RENAME_DISTANCE_M = 50
 
 
 def _outer_shell(geom):
@@ -92,6 +95,35 @@ def assign_parent_child(features):
                     f"{slugify(new_name)}-{hash_centroid(centroid)}"
                 )
 
+
+def rename_by_proximity(features, threshold_m=NEARBY_RENAME_DISTANCE_M):
+    points_m = [transform(_TO_M, Point(f["properties"]["centroid"])) for f in features]
+    names = [f["properties"].get("name", "") for f in features]
+
+    for i, feat in enumerate(features):
+        props = feat["properties"]
+        name = props.get("name", "")
+        if not name.startswith("Unnamed ") or props.get("overlap_role") != "solo":
+            continue
+
+        pt = points_m[i]
+        best_idx = None
+        best_dist = None
+        for j, other_name in enumerate(names):
+            if i == j or other_name.startswith("Unnamed "):
+                continue
+            dist = pt.distance(points_m[j])
+            if best_dist is None or dist < best_dist:
+                best_dist = dist
+                best_idx = j
+        if best_idx is not None and best_dist <= threshold_m:
+            feature_type = name[len("Unnamed ") :]
+            near_name = names[best_idx]
+            new_name = f"{feature_type} near {near_name}"
+            props["name"] = new_name
+            centroid = tuple(props.get("centroid", []))
+            props["id"] = f"{slugify(new_name)}-{hash_centroid(centroid)}"
+            names[i] = new_name
 
 def process_features(osm_data):
     print("Processing features...")
@@ -256,5 +288,6 @@ def process_features(osm_data):
     print(f"Removed {removed_dupes} duplicate feature(s) by centroid")
     features = list(deduped.values())
     assign_parent_child(features)
+    rename_by_proximity(features)
     print(f"Generated {len(features)} features")
     return features


### PR DESCRIPTION
## Summary
- add proximity-based renaming for unnamed features
- include threshold constant for nearby naming

## Testing
- `npm test`
- `python -m py_compile ucla_geojson/builder.py`


------
https://chatgpt.com/codex/tasks/task_e_689edb054f98832285da46ec9b12b527