### PR TITLE
feat: report GeoJSON build stage timings

### DIFF
--- a/ucla_geojson/main.py
+++ b/ucla_geojson/main.py
@@ -1,3 +1,5 @@
+from time import perf_counter
+
 from .fetcher import fetch_osm_data
 from .builder import process_features
 from .writer import write_single
@@ -5,7 +7,21 @@ from .writer import write_single
 
 def main():
     print("Starting build_ucla_geojson...")
-    data = fetch_osm_data()
-    features = process_features(data)
-    write_single(features)
-    print(f"Done. Wrote {len(features)} features to public/campus.geojson")
+    start_time = perf_counter()
+
+    data = timed("fetch_osm_data", fetch_osm_data)
+    features = timed("process_features", process_features, data)
+    timed("write_single", write_single, features)
+
+    total_time = perf_counter() - start_time
+    print(
+        f"Done. Wrote {len(features)} features to public/campus.geojson in {total_time:.2f} seconds"
+    )
+
+
+def timed(label, func, *args, **kwargs):
+    start = perf_counter()
+    result = func(*args, **kwargs)
+    duration = perf_counter() - start
+    print(f"{label} took {duration:.2f} seconds")
+    return result


### PR DESCRIPTION
## Summary
- replace manual perf_counter bookkeeping with a reusable timed helper
- keep total runtime reporting after writing GeoJSON

## Testing
- `npm test`
- `python build_ucla_geojson.py` *(fails: ModuleNotFoundError: No module named 'pyproj')*

------
https://chatgpt.com/codex/tasks/task_e_689fd2d1c88883229e29e3fbb5519806