### PR TITLE
Include lower education amenities

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -5,6 +5,7 @@ import Fuse from "fuse.js";
 
 const CATEGORY_COLOR_ENTRIES = [
   ["Academic/Research", "#1f77b4"],
+  ["Lower Education", "#aec7e8"],
   ["Clinic/Health", "#8c564b"],
   ["Food Service", "#d62728"],
   ["Hospital", "#c49c94"],

--- a/ucla_geojson/classification.py
+++ b/ucla_geojson/classification.py
@@ -203,6 +203,9 @@ def determine_category(tags: Dict[str, str], name: str, zone: str) -> str:
         cat = "Hospital" if "hospital" in (amenity + " " + name_norm) else "Clinic/Health"
         return cat
 
+    if amenity in {"school", "kindergarten"} or btype in {"school", "kindergarten"}:
+        return "Lower Education"
+
     if (
         btype in {"residential", "dormitory", "apartments", "fraternity", "sorority"}
         or amenity in {"fraternity", "sorority"}

--- a/ucla_geojson/fetcher.py
+++ b/ucla_geojson/fetcher.py
@@ -18,6 +18,8 @@ area["amenity"="university"]["name"~"^(University of California, Los Angeles|UCL
   relation["building"](area.ucla);
   way["shop"](area.ucla);
   relation["shop"](area.ucla);
+  way["amenity"~"^(school|kindergarten)$"](area.ucla);
+  relation["amenity"~"^(school|kindergarten)$"](area.ucla);
   way["amenity"="parking"][!building](area.ucla);
   relation["amenity"="parking"][!building](area.ucla);
   way["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"](area.ucla);
@@ -38,6 +40,10 @@ area["amenity"="university"]["name"~"^(University of California, Los Angeles|UCL
   way["shop"]["operator"~"UCLA",i]{BBOX_QUERY};
   relation["shop"]["name"~"UCLA",i]{BBOX_QUERY};
   relation["shop"]["operator"~"UCLA",i]{BBOX_QUERY};
+  way["amenity"~"^(school|kindergarten)$"]["name"~"UCLA",i]{BBOX_QUERY};
+  way["amenity"~"^(school|kindergarten)$"]["operator"~"UCLA",i]{BBOX_QUERY};
+  relation["amenity"~"^(school|kindergarten)$"]["name"~"UCLA",i]{BBOX_QUERY};
+  relation["amenity"~"^(school|kindergarten)$"]["operator"~"UCLA",i]{BBOX_QUERY};
   way["amenity"="parking"][!building]["name"~"UCLA",i]{BBOX_QUERY};
   way["amenity"="parking"][!building]["operator"~"UCLA",i]{BBOX_QUERY};
   relation["amenity"="parking"][!building]["name"~"UCLA",i]{BBOX_QUERY};


### PR DESCRIPTION
## Summary
- fetch Overpass features tagged as schools or kindergartens
- classify school features as "Lower Education"
- add map colors for Lower Education category

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe448dc5083228ed01b78d4c7cb42