### PR TITLE
Refactor OSM fetch and add async split

### DIFF
--- a/ucla_geojson/fetcher.py
+++ b/ucla_geojson/fetcher.py
@@ -1,91 +1,142 @@
+import asyncio
 import json
 import urllib.parse
 import urllib.request
+from typing import Dict, Iterable, List, Tuple
 
 from .constants import BBOX_QUERY, GREEK_NAME_RE, OVERPASS_URL
 
 
-def fetch_osm_data():
-    query = f"""
-[out:json][timeout:90];
+BASE_LINES = [
+    "[out:json][timeout:90];",
+    "",
+    'area["amenity"="university"]["name"~"^(University of California, Los Angeles|UCLA)$",i]->.ucla;',
+]
 
-// Get UCLA campus area(s)
-area["amenity"="university"]["name"~"^(University of California, Los Angeles|UCLA)$",i]->.ucla;
 
-// Get buildings, shops, and recreational areas inside UCLA campus
-(
-  way["building"](area.ucla);
-  relation["building"](area.ucla);
-  way["shop"](area.ucla);
-  relation["shop"](area.ucla);
-  way["amenity"~"^(school|kindergarten)$"](area.ucla);
-  relation["amenity"~"^(school|kindergarten)$"](area.ucla);
-  way["amenity"="parking"][!building](area.ucla);
-  relation["amenity"="parking"][!building](area.ucla);
-  way["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"](area.ucla);
-  relation["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"](area.ucla);
-    way["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"](area.ucla);
-    relation["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"](area.ucla);
-    way["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"](area.ucla);
-    relation["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"](area.ucla);
-)->.campus;
+def _tag_lines(tags: Iterable[str], location: str) -> List[str]:
+    lines: List[str] = []
+    for element in ("way", "relation"):
+        for tag in tags:
+            lines.append(f"{element}{tag}{location};")
+    return lines
 
-// Also get *any* building, shop, or recreational area with name/operator containing UCLA in bbox
-(
-  way["building"]["name"~"UCLA",i]{BBOX_QUERY};
-  way["building"]["operator"~"UCLA",i]{BBOX_QUERY};
-  relation["building"]["name"~"UCLA",i]{BBOX_QUERY};
-  relation["building"]["operator"~"UCLA",i]{BBOX_QUERY};
-  way["shop"]["name"~"UCLA",i]{BBOX_QUERY};
-  way["shop"]["operator"~"UCLA",i]{BBOX_QUERY};
-  relation["shop"]["name"~"UCLA",i]{BBOX_QUERY};
-  relation["shop"]["operator"~"UCLA",i]{BBOX_QUERY};
-  way["amenity"~"^(school|kindergarten)$"]["name"~"UCLA",i]{BBOX_QUERY};
-  way["amenity"~"^(school|kindergarten)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-  relation["amenity"~"^(school|kindergarten)$"]["name"~"UCLA",i]{BBOX_QUERY};
-  relation["amenity"~"^(school|kindergarten)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-  way["amenity"="parking"][!building]["name"~"UCLA",i]{BBOX_QUERY};
-  way["amenity"="parking"][!building]["operator"~"UCLA",i]{BBOX_QUERY};
-  relation["amenity"="parking"][!building]["name"~"UCLA",i]{BBOX_QUERY};
-  relation["amenity"="parking"][!building]["operator"~"UCLA",i]{BBOX_QUERY};
-  way["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]["name"~"UCLA",i]{BBOX_QUERY};
-  way["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-  relation["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]["name"~"UCLA",i]{BBOX_QUERY};
-  relation["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-    way["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]["name"~"UCLA",i]{BBOX_QUERY};
-    way["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-    relation["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]["name"~"UCLA",i]{BBOX_QUERY};
-    relation["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-    way["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]["name"~"UCLA",i]{BBOX_QUERY};
-    way["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-    relation["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]["name"~"UCLA",i]{BBOX_QUERY};
-    relation["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]["operator"~"UCLA",i]{BBOX_QUERY};
-)->.ucla_related;
 
-// Get fraternities and sororities in the bounding box (many are just building=yes with Greek names)
-(
-  way["amenity"="fraternity"]{BBOX_QUERY};
-  way["amenity"="sorority"]{BBOX_QUERY};
-  way["building"="fraternity"]{BBOX_QUERY};
-  way["building"="sorority"]{BBOX_QUERY};
+def _campus_lines() -> List[str]:
+    tags = [
+        '["building"]',
+        '["shop"]',
+        '["amenity"~"^(school|kindergarten)$"]',
+        '["amenity"="parking"][!building]',
+        '["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]',
+        '["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]',
+        '["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]',
+    ]
+    return _tag_lines(tags, "(area.ucla)")
 
-  relation["amenity"="fraternity"]{BBOX_QUERY};
-  relation["amenity"="sorority"]{BBOX_QUERY};
-  relation["building"="fraternity"]{BBOX_QUERY};
-  relation["building"="sorority"]{BBOX_QUERY};
 
-  way["building"]["name"~"{GREEK_NAME_RE}",i]{BBOX_QUERY};
-  way["building"]["operator"~"{GREEK_NAME_RE}",i]{BBOX_QUERY};
-  relation["building"]["name"~"{GREEK_NAME_RE}",i]{BBOX_QUERY};
-  relation["building"]["operator"~"{GREEK_NAME_RE}",i]{BBOX_QUERY};
-)->.greek;
+def _ucla_related_lines() -> List[str]:
+    tags = [
+        '["building"]',
+        '["shop"]',
+        '["amenity"~"^(school|kindergarten)$"]',
+        '["amenity"="parking"][!building]',
+        '["leisure"~"^(stadium|sports_centre|pitch|swimming_pool|track|tennis_court|park|garden)$"]',
+        '["landuse"~"^(grass|recreation_ground|forest|meadow|shrubland)$"]',
+        '["natural"~"^(scrub|shrub|shrubland|wood|grassland)$"]',
+    ]
+    lines: List[str] = []
+    for element in ("way", "relation"):
+        for tag in tags:
+            for attr in ("name", "operator"):
+                lines.append(
+                    f"{element}{tag}[\"{attr}\"~\"UCLA\",i]{BBOX_QUERY};"
+                )
+    return lines
 
-// Combine and include UCLA campus boundary relation for on-campus checks
-(.campus; .ucla_related; .greek; relation(7493269););
-out body; >; out skel qt;
-"""
-    url = f"{OVERPASS_URL}?{urllib.parse.urlencode({'data': query})}"
-    with urllib.request.urlopen(url) as resp:
-        data = json.load(resp)
+
+def _greek_lines() -> List[str]:
+    lines: List[str] = []
+    values = ["fraternity", "sorority"]
+    for element in ("way", "relation"):
+        for val in values:
+            lines.append(f"{element}[\"amenity\"=\"{val}\"]{BBOX_QUERY};")
+            lines.append(f"{element}[\"building\"=\"{val}\"]{BBOX_QUERY};")
+    for element in ("way", "relation"):
+        for attr in ("name", "operator"):
+            lines.append(
+                f"{element}[\"building\"][\"{attr}\"~\"{GREEK_NAME_RE}\",i]{BBOX_QUERY};"
+            )
+    return lines
+
+
+def _wrap(lines: Iterable[str], name: str) -> List[str]:
+    return ["("] + list(lines) + [f")->.{name};"]
+
+
+def _build_query() -> Tuple[str, Dict[str, str]]:
+    sections = {
+        "campus": _campus_lines(),
+        "ucla_related": _ucla_related_lines(),
+        "greek": _greek_lines(),
+    }
+    body: List[str] = []
+    for name, lines in sections.items():
+        body.extend(_wrap(lines, name))
+    final_lines = (
+        BASE_LINES
+        + body
+        + ["(.campus; .ucla_related; .greek; relation(7493269););", "out body; >; out skel qt;"]
+    )
+    single = "\n".join(final_lines)
+
+    split_queries: Dict[str, str] = {}
+    for name, lines in sections.items():
+        tail = f"(.{name}; {'relation(7493269);' if name == 'campus' else ''});"
+        q_lines = BASE_LINES + _wrap(lines, name) + [tail, "out body; >; out skel qt;"]
+        split_queries[name] = "\n".join(q_lines)
+
+    return single, split_queries
+
+
+def _build_url(query: str) -> str:
+    return f"{OVERPASS_URL}?{urllib.parse.urlencode({'data': query})}"
+
+
+async def _fetch(query: str) -> Dict[str, object]:
+    url = _build_url(query)
+
+    def _read() -> Dict[str, object]:
+        with urllib.request.urlopen(url) as resp:
+            return json.load(resp)
+
+    data = await asyncio.to_thread(_read)
     print(f"Fetched {len(data.get('elements', []))} elements")
     return data
+
+
+async def fetch_osm_data_async(split: bool = True) -> Dict[str, object]:
+    single_query, split_queries = _build_query()
+    if not split:
+        return await _fetch(single_query)
+
+    tasks = [_fetch(q) for q in split_queries.values()]
+    results = await asyncio.gather(*tasks)
+    combined: Dict[str, object] = {"elements": []}
+    seen = set()
+    for data in results:
+        for el in data.get("elements", []):
+            key = (el.get("type"), el.get("id"))
+            if key not in seen:
+                combined["elements"].append(el)
+                seen.add(key)
+    print(f"Fetched {len(combined['elements'])} combined elements")
+    return combined
+
+
+def fetch_osm_data(split: bool = True) -> Dict[str, object]:
+    return asyncio.run(fetch_osm_data_async(split=split))
+
+
+__all__ = ["fetch_osm_data"]
+

--- a/ucla_geojson/main.py
+++ b/ucla_geojson/main.py
@@ -9,7 +9,7 @@ def main():
     print("Starting build_ucla_geojson...")
     start_time = perf_counter()
 
-    data = timed("fetch_osm_data", fetch_osm_data)
+    data = timed("fetch_osm_data", fetch_osm_data, split=True)
     features = timed("process_features", process_features, data)
     timed("write_single", write_single, features)
 


### PR DESCRIPTION
## Summary
- refactor OSM data fetching to build queries programmatically
- add asynchronous split fetching with deduplication
- run fetch step in parallel by default

## Testing
- `python -m py_compile ucla_geojson/*.py`
- Attempted `python build_ucla_geojson.py` *(fails: ModuleNotFoundError: No module named 'pyproj')*
- Attempted `pip install pyproj` *(fails: Could not find a version that satisfies the requirement pyproj)*

------
https://chatgpt.com/codex/tasks/task_e_689feaa301388322b2dd39b318149966