### PR TITLE
Assign Westwood zone to off-campus features

### DIFF
--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -274,6 +274,8 @@ export default function MapView({
       const res = await fetch("/campus.geojson");
       const data = await res.json();
 
+      data.features = data.features.filter((f) => f.properties.render === true);
+
       data.features.forEach((f) => {
         const p = f.properties;
         const name = p.name?.toLowerCase() || "";


### PR DESCRIPTION
## Summary
- classify non-campus features as Westwood while using campus zones for intersecting features
- set `render: true` by default and skip non-renderable features when loading campus data

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0df337d00832291d1c483894ad902