### PR TITLE
Add caching for fetcher queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ thumb
 sketch
 
 # End of https://www.toptal.com/developers/gitignore/api/node,python,react
+ucla_geojson/cache/


### PR DESCRIPTION
## Summary
- hash built Overpass query URLs and cache responses on disk
- log when cached responses are used or saved
- ignore cache directory

## Testing
- `python -m py_compile ucla_geojson/fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_68a25e0949ec83229b47ed1ec4336b02