### PR TITLE
Display coordinates for query results

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,11 @@ export default function App() {
   const [showUnnamed, setShowUnnamed] = useState(true);
   const [colorBy, setColorBy] = useState("category");
   const [queryMode, setQueryMode] = useState(false);
-  const [queryResults, setQueryResults] = useState([]);
+  const [queryResults, setQueryResults] = useState({
+    lngLat: null,
+    point: null,
+    features: [],
+  });
   const [trainingMode, setTrainingMode] = useState(false);
 
   return (

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -136,7 +136,7 @@ export default function MapView({
   useEffect(() => {
     queryModeRef.current = queryMode;
     if (!queryMode) {
-      setQueryResults([]);
+      setQueryResults({ lngLat: null, point: null, features: [] });
     }
   }, [queryMode, setQueryResults]);
 
@@ -472,7 +472,11 @@ export default function MapView({
           return;
         }
         if (queryModeRef.current) {
-          setQueryResults(features);
+          setQueryResults({
+            lngLat: { lng: e.lngLat.lng, lat: e.lngLat.lat },
+            point: { x: e.point.x, y: e.point.y },
+            features,
+          });
           setStatus(
             `Found ${features.length} feature${features.length !== 1 ? "s" : ""}`
           );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -113,7 +113,7 @@ export default function Sidebar({
       >
         {status}
       </div>
-      {queryResults.length > 0 && (
+      {queryResults.lngLat && (
         <div
           style={{
             marginTop: 8,
@@ -125,7 +125,23 @@ export default function Sidebar({
             background: "#fff",
           }}
         >
-          {queryResults.map((f, idx) => (
+          <div style={{ marginBottom: 8 }}>
+            <div style={{ fontWeight: "bold" }}>Clicked point</div>
+            <pre
+              style={{
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                fontSize: 12,
+              }}
+            >
+              {JSON.stringify(
+                { lngLat: queryResults.lngLat, point: queryResults.point },
+                null,
+                2
+              )}
+            </pre>
+          </div>
+          {queryResults.features.map((f, idx) => (
             <div key={idx} style={{ marginBottom: 8 }}>
               <div style={{ fontWeight: "bold" }}>
                 {f.properties.name || f.properties.id || `Feature ${idx + 1}`}


### PR DESCRIPTION
## Summary
- show clicked point longitude/latitude and pixel location
- retain overlapping features from query clicks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a262d1d2ec8322a65f7464a63611b4